### PR TITLE
Fix QrToken.Wait method to use a int32 default value instead of int 

### DIFF
--- a/telegram/auth.go
+++ b/telegram/auth.go
@@ -339,7 +339,8 @@ func (q *QrToken) Recreate() (*QrToken, error) {
 }
 
 func (q *QrToken) Wait(timeout ...int32) error {
-	q.Timeout = getVariadic(timeout, 600).(int32) // 10 minutes
+	const def int32 = 600 // 10 minutes
+	q.Timeout = getVariadic(timeout, def).(int32)
 	ch := make(chan int)
 	ev := q.client.AddRawHandler(&UpdateLoginToken{}, func(update Update) error {
 		ch <- 1


### PR DESCRIPTION
The fact that the value 600 is inline and not as part of a const or var declaration, go defaults its type to int,
which causes an error: `interface conversion: interface {} is int, not int32`.

This pull requests fixes this by declaring the default value as a `const int32`

