### PR TITLE
Fix support  for socks proxy

### DIFF
--- a/examples/proxy/proxy.go
+++ b/examples/proxy/proxy.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/amarnathcjd/gogram/telegram"
+)
+
+const (
+	appID    = 1025907
+	appHash  = "452b0359b988148995f22ff0f4229750"
+	phoneNum = "+1026164213164"
+)
+
+func main() {
+	// Create a new client
+	client, _ := telegram.NewClient(telegram.ClientConfig{
+		AppID:    appID,
+		AppHash:  appHash,
+		LogLevel: telegram.LogInfo,
+		SocksProxy: &url.URL{
+			Scheme: "socks5",
+			Host:   "127.0.0.1:1080",
+			// User:   url.UserPassword("username", "password"),
+		},
+	})
+
+	// Connect to the server
+	if err := client.Connect(); err != nil {
+		panic(err)
+	}
+
+	// Authenticate the client using the bot token
+	// This will send a code to the phone number if it is not already authenticated
+	if _, err := client.Login(phoneNum); err != nil {
+		panic(err)
+	}
+
+	// Do something with the client
+	// ...
+	me, err := client.GetMe()
+	if err != nil {
+		panic(err)
+	}
+	client.SendMessage("me", fmt.Sprintf("Hello, %s!", me.FirstName))
+	fmt.Println("Logged in as", me.Username)
+}

--- a/internal/transport/connection.go
+++ b/internal/transport/connection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"net/url"
 	"time"
 
 	"github.com/pkg/errors"
@@ -19,7 +20,7 @@ type TCPConnConfig struct {
 	Ctx     context.Context
 	Host    string
 	Timeout time.Duration
-	Socks   *Socks
+	Socks   *url.URL
 }
 
 func NewTCP(cfg TCPConnConfig) (Conn, error) {

--- a/mtproto.go
+++ b/mtproto.go
@@ -194,7 +194,16 @@ func (m *MTProto) ReconnectToNewDC(dc int) (*MTProto, error) {
 	}
 	m.sessionStorage.Delete()
 	m.Logger.Debug("deleted old auth key file")
-	cfg := Config{DataCenter: dc, PublicKey: m.PublicKey, ServerHost: newAddr, AuthKeyFile: m.sessionStorage.Path(), MemorySession: false, LogLevel: m.Logger.Lev(), SocksProxy: m.socksProxy, AppID: m.appID}
+	cfg := Config{
+		DataCenter:    dc,
+		PublicKey:     m.PublicKey,
+		ServerHost:    newAddr,
+		AuthKeyFile:   m.sessionStorage.Path(),
+		MemorySession: m.memorySession,
+		LogLevel:      m.Logger.Lev(),
+		SocksProxy:    m.socksProxy,
+		AppID:         m.appID,
+	}
 	sender, err := NewMTProto(cfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating new MTProto")

--- a/telegram/client.go
+++ b/telegram/client.go
@@ -67,6 +67,7 @@ type ClientConfig struct {
 	StringSession string
 	LangCode      string
 	ParseMode     string
+	MemorySession bool
 	DataCenter    int
 	PublicKeys    []*rsa.PublicKey
 	NoUpdates     bool
@@ -101,6 +102,7 @@ func (c *Client) setupMTProto(config ClientConfig) error {
 		LogLevel:      LIB_LOG_LEVEL,
 		StringSession: config.StringSession,
 		SocksProxy:    config.SocksProxy,
+		MemorySession: config.MemorySession,
 	})
 	if err != nil {
 		return errors.Wrap(err, "creating mtproto client")

--- a/telegram/client.go
+++ b/telegram/client.go
@@ -4,6 +4,7 @@ package telegram
 
 import (
 	"crypto/rsa"
+	"net/url"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -70,6 +71,7 @@ type ClientConfig struct {
 	PublicKeys    []*rsa.PublicKey
 	NoUpdates     bool
 	LogLevel      string
+	SocksProxy    *url.URL
 }
 
 func NewClient(config ClientConfig) (*Client, error) {
@@ -90,7 +92,16 @@ func NewClient(config ClientConfig) (*Client, error) {
 }
 
 func (c *Client) setupMTProto(config ClientConfig) error {
-	mtproto, err := mtproto.NewMTProto(mtproto.Config{AppID: config.AppID, AuthKeyFile: config.Session, ServerHost: GetHostIp(config.DataCenter), PublicKey: config.PublicKeys[0], DataCenter: config.DataCenter, LogLevel: LIB_LOG_LEVEL, StringSession: config.StringSession})
+	mtproto, err := mtproto.NewMTProto(mtproto.Config{
+		AppID:         config.AppID,
+		AuthKeyFile:   config.Session,
+		ServerHost:    GetHostIp(config.DataCenter),
+		PublicKey:     config.PublicKeys[0],
+		DataCenter:    config.DataCenter,
+		LogLevel:      LIB_LOG_LEVEL,
+		StringSession: config.StringSession,
+		SocksProxy:    config.SocksProxy,
+	})
 	if err != nil {
 		return errors.Wrap(err, "creating mtproto client")
 	}


### PR DESCRIPTION
When we call NewMTProto, it doesn't set MTProto.socksProxy to c.SocksProxy.
```
	mtproto := &MTProto{sessionStorage: c.SessionStorage, Addr: c.ServerHost, encrypted: false, sessionId: utils.GenerateSessionID(), serviceChannel: make(chan tl.Object), PublicKey: c.PublicKey, responseChannels: utils.NewSyncIntObjectChan(), expectedTypes: utils.NewSyncIntReflectTypes(), serverRequestHandlers: make([]func(i any) bool, 0), Logger: utils.NewLogger("gogram - mtproto").SetLevel(c.LogLevel), memorySession: c.MemorySession, appID: c.AppID}
```

This will cause NewTCP does not call newSocksTCP, so socks proxy won't work.
```
func NewTCP(cfg TCPConnConfig) (Conn, error) {
	if cfg.Socks != nil && cfg.Socks.Host != "" {
		return newSocksTCP(cfg)
	}
	...
}
```