### PR TITLE
Fix filename for file upload

### DIFF
--- a/telegram/media.go
+++ b/telegram/media.go
@@ -100,7 +100,9 @@ func (u *Uploader) Init() error {
 				return errors.Wrap(err, "can not get file size")
 			}
 			u.Meta.FileSize = fi.Size()
-			u.Meta.FileName = fi.Name()
+			if u.Meta.FileName == "" {
+				u.Meta.FileName = fi.Name()
+			}
 		}
 	case []byte:
 		u.Meta.FileSize = int64(len(s))
@@ -110,7 +112,9 @@ func (u *Uploader) Init() error {
 			return err
 		}
 		u.Meta.FileSize = fi.Size()
-		u.Meta.FileName = fi.Name()
+		if u.Meta.FileName == "" {
+			u.Meta.FileName = fi.Name()
+		}
 	case io.Reader:
 		buff := bytes.NewBuffer([]byte{})
 		fs, err := io.Copy(buff, s)


### PR DESCRIPTION
Right now provided filename for file upload is ignored. 
https://github.com/AmarnathCJD/gogram/blob/7677938237dac96a7affa9711f010cd4e44939b2/telegram/media.go#L102-L104
https://github.com/AmarnathCJD/gogram/blob/7677938237dac96a7affa9711f010cd4e44939b2/telegram/media.go#L112-L114

This PR fixes this and uses filename passed from opts