### PR TITLE
fix: no cache check for `InputPeerChannel` & `InputPeerUser`

### DIFF
--- a/telegram/helpers.go
+++ b/telegram/helpers.go
@@ -267,11 +267,7 @@ PeerSwitch:
 	case *InputPeerChat:
 		return Peer, nil
 	case *InputPeerChannel:
-		peerEntity, err := c.GetPeerChannel(Peer.ChannelID)
-		if err != nil {
-			return nil, err
-		}
-		return &InputPeerChannel{ChannelID: peerEntity.ChannelID, AccessHash: peerEntity.AccessHash}, nil
+		return Peer, nil
 	case *InputPeerUser:
 		peerEntity, err := c.GetPeerUser(Peer.UserID)
 		if err != nil {

--- a/telegram/helpers.go
+++ b/telegram/helpers.go
@@ -269,11 +269,7 @@ PeerSwitch:
 	case *InputPeerChannel:
 		return Peer, nil
 	case *InputPeerUser:
-		peerEntity, err := c.GetPeerUser(Peer.UserID)
-		if err != nil {
-			return nil, err
-		}
-		return &InputPeerUser{UserID: peerEntity.UserID, AccessHash: peerEntity.AccessHash}, nil
+		return Peer, nil
 	case *InputPeer:
 		return *Peer, nil
 		// TODO: Add more types


### PR DESCRIPTION
InputPeerChannel already has ChannelID and AccessHash in it, so no need to check our cache