### PR TITLE
feature: replaced *bytes.Buffer with io.Writer

### DIFF
--- a/telegram/media.go
+++ b/telegram/media.go
@@ -329,7 +329,7 @@ type DownloadOptions struct {
 	// Datacenter ID of file
 	DCId int32 `json:"dc_id,omitempty"`
 	// Destination Writer
-	Buffer *bytes.Buffer `json:"-"`
+	Buffer io.Writer `json:"-"`
 }
 
 type Destination struct {


### PR DESCRIPTION
replaced *bytes.Buffer with io.Writer to be able to use any kind of buffers.

I needed to compute a hash as I downloaded the file and for that I needed to implement use an io.Writer instead of a *bytes.Buffer.

Here is an example of the usage afterwards

```
type HashWriter struct {
	w io.Writer
	h hash.Hash
}

func NewHashWriter(w io.Writer, h hash.Hash) *HashWriter {
	return &HashWriter{
		w: w,
		h: h,
	}
}

func (hw *HashWriter) Read(b []byte) (int, error) {
	return hw.Read(b)
}

func (hw *HashWriter) Write(b []byte) (int, error) {
	_, err := hw.h.Write(b)
	if err != nil {
		return 0, fmt.Errorf("writing hash: %w", err)
	}
	return hw.w.Write(b)
}

func (hw *HashWriter) Sum(b []byte) []byte {
	return hw.h.Sum(b)
}

func (hw *HashWriter) String() string {
	return fmt.Sprintf("%x", hw.h.Sum(nil))
}

func Download(client *telegram.Client, m *telegram.DocumentObj) (io.Reader, error) {
	_, dcid, _, _, err := telegram.GetFileLocation(m)
	if err != nil {
		return nil, fmt.Errorf("got error getting file info: %w", err)
	}
	buf := &bytes.Buffer{}
	hw := NewHashWriter(buf, sha256.New())
	_, err = client.DownloadMedia(m, &telegram.DownloadOptions{Buffer: hw, DCId: dcid})
	if err != nil {
		return nil, fmt.Errorf("got error getting file: %w", err)
	}
	return hw, fmt.Errorf("got error getting file: %w", err)
}
```