### PR TITLE
fix(telegram): ensure ForceDocument in MediaOptions applies to photos

### DIFF
--- a/telegram/helpers.go
+++ b/telegram/helpers.go
@@ -534,10 +534,10 @@ mediaTypeSwitch:
 			mimeType = attr.MimeType
 		}
 
-		if IsPhoto {
+		if IsPhoto && !attr.ForceDocument {
 			return &InputMediaUploadedPhoto{File: mediaFile, TtlSeconds: getValue(attr.TTL, 0), Spoiler: getValue(attr.Spoiler, false)}, nil
 		} else {
-			var mediaAttributes = getValueSlice(attr.Attributes, []DocumentAttribute{&DocumentAttributeFilename{FileName: fileName}})
+			mediaAttributes := getValueSlice(attr.Attributes, []DocumentAttribute{&DocumentAttributeFilename{FileName: fileName}})
 			hasFileName := false
 			mediaAttributes, dur, err := gatherVideoMetadata(getValue(attr.FileAbsPath, fileName), mediaAttributes)
 			if err != nil {


### PR DESCRIPTION
Fixed an issue where the `ForceDocument` option in `telegram.MediaOptions` was not functioning correctly for photos. Now, when `ForceDocument` is true, photos will be treated as documents. This change also includes minor refactoring of variable declaration in the same logic block.