### PR TITLE
Small Bugfix

### DIFF
--- a/telegram/formatting.go
+++ b/telegram/formatting.go
@@ -263,7 +263,7 @@ func InsertTagsIntoText(text string, tags []Tag) string {
 		closeTags[int(tag.Offset+tag.Length)] = append(closeTags[int(tag.Offset+tag.Length)], tag)
 	}
 
-	result := make([]uint16, len(utf16Text))
+	result := make([]uint16, 0, len(utf16Text)*2)
 	for i := 0; i < len(utf16Text); i++ {
 		if opening, exists := openTags[i]; exists {
 			for _, tag := range opening {


### PR DESCRIPTION
I fucked up and initialized the slice with a length instead of a cap. While it doesn't affect the results, it affects the performance (by reallocating the slice on append) and forces the utf16 decoder do decode a few extra zeroes