### PR TITLE
Implement local address configuration for multi-interface support

### DIFF
--- a/telegram/client.go
+++ b/telegram/client.go
@@ -86,6 +86,7 @@ type ClientConfig struct {
 	LogLevel         utils.LogLevel       // The library log level
 	Logger           *utils.Logger        // The logger to use
 	Proxy            *url.URL             // The proxy to use (SOCKS5, HTTP)
+	LocalAddr        string               // Local address binding for multi-interface support (IP:port)
 	ForceIPv6        bool                 // Force to use IPv6
 	NoPreconnect     bool                 // Don't preconnect to the DC until Connect() is called
 	Cache            *CACHE               // The cache to use
@@ -184,6 +185,7 @@ func (c *Client) setupMTProto(config ClientConfig) error {
 			NoColor(!c.Log.Color()),
 		StringSession: config.StringSession,
 		Proxy:         config.Proxy,
+		LocalAddr:     config.LocalAddr,
 		MemorySession: config.MemorySession,
 		Ipv6:          config.ForceIPv6,
 		CustomHost:    customHost,
@@ -867,6 +869,11 @@ func (b *ClientConfigBuilder) WithDataCenter(dc int) *ClientConfigBuilder {
 
 func (b *ClientConfigBuilder) WithProxy(proxyURL *url.URL) *ClientConfigBuilder {
 	b.config.Proxy = proxyURL
+	return b
+}
+
+func (b *ClientConfigBuilder) WithLocalAddr(localAddr string) *ClientConfigBuilder {
+	b.config.LocalAddr = localAddr
 	return b
 }
 


### PR DESCRIPTION
This feature allows binding Telegram client connections to specific local network interfaces or IP addresses. This is particularly useful for:

- Running multiple Telegram accounts from different IP addresses on the same server to avoid rate limiting and account associations
- Ensuring specific accounts use specific network routes for compliance or security requirements

The implementation adds a LocalAddr field to ClientConfig that accepts standard address formats like "192.168.1.100:0" or ":8888". If not specified, the system automatically selects the interface as before, maintaining backward compatibility.