### PR TITLE
Add optional request timeout

### DIFF
--- a/mtproto.go
+++ b/mtproto.go
@@ -87,6 +87,7 @@ type MTProto struct {
 	exported              bool
 	cdn                   bool
 	terminated            atomic.Bool
+	timeout               time.Duration
 }
 
 type Config struct {
@@ -109,6 +110,7 @@ type Config struct {
 	Ipv6       bool
 	CustomHost bool
 	LocalAddr  string
+	Timeout    time.Duration
 }
 
 func NewMTProto(c Config) (*MTProto, error) {
@@ -158,6 +160,7 @@ func NewMTProto(c Config) (*MTProto, error) {
 		IpV6:                  c.Ipv6,
 		tcpState:              NewTcpState(),
 		DcList:                utils.NewDCOptions(),
+		timeout:               c.Timeout,
 	}
 
 	mtproto.Logger.Debug("initializing mtproto...")
@@ -302,6 +305,7 @@ func (m *MTProto) SwitchDc(dc int) (*MTProto, error) {
 		LocalAddr:     m.localAddr,
 		AppID:         m.appID,
 		Ipv6:          m.IpV6,
+		Timeout:       m.timeout,
 	}
 
 	sender, err := NewMTProto(cfg)
@@ -339,6 +343,7 @@ func (m *MTProto) ExportNewSender(dcID int, mem bool, cdn ...bool) (*MTProto, er
 		LocalAddr:     m.localAddr,
 		AppID:         m.appID,
 		Ipv6:          m.IpV6,
+		Timeout:       m.timeout,
 	}
 
 	if dcID == m.GetDC() {

--- a/network.go
+++ b/network.go
@@ -169,6 +169,11 @@ func (m *MTProto) SetAuthKey(key []byte) {
 }
 
 func (m *MTProto) MakeRequest(msg tl.Object) (any, error) {
+	if m.timeout > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
+		defer cancel()
+		return m.makeRequestCtx(ctx, msg)
+	}
 	return m.makeRequest(msg)
 }
 

--- a/telegram/client.go
+++ b/telegram/client.go
@@ -96,6 +96,7 @@ type ClientConfig struct {
 	AlbumWaitTime    int64                // The time to wait for album messages (in milliseconds)
 	FloodHandler     func(err error) bool // The flood handler to use
 	ErrorHandler     func(err error)      // The error handler to use
+	Timeout          time.Duration        // Request timeout (no timeout by default)
 }
 
 type Session struct {
@@ -191,6 +192,7 @@ func (c *Client) setupMTProto(config ClientConfig) error {
 		CustomHost:    customHost,
 		FloodHandler:  config.FloodHandler,
 		ErrorHandler:  config.ErrorHandler,
+		Timeout:       config.Timeout,
 	})
 	if err != nil {
 		return errors.Wrap(err, "creating mtproto client")


### PR DESCRIPTION
Added support for setting a timeout on all requests.
This prevents the library from hanging indefinitely if the Telegram server doesn’t respond.
The change is backward-compatible — if no timeout is set, everything works as before.