### PR TITLE
Fix download hanging and add timeout support

### DIFF
--- a/examples/download/main.go
+++ b/examples/download/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"time"
+
+	"github.com/amarnathcjd/gogram/telegram"
+)
+
+const (
+	appID    = 6
+	appHash  = "YOUR_APP_HASH"
+	botToken = "YOUR_BOT_TOKEN"
+)
+
+func main() {
+	client, _ := telegram.NewClient(telegram.ClientConfig{
+		AppID:    appID,
+		AppHash:  appHash,
+		LogLevel: telegram.LogInfo,
+	})
+
+	client.LoginBot(botToken)
+
+	client.On(telegram.OnMessage, func(message *telegram.NewMessage) error {
+		if !message.IsMedia() {
+			return nil
+		}
+
+		pm := telegram.NewProgressManager(5).SetMessage(message)
+
+		_, err := message.Download(&telegram.DownloadOptions{
+			ProgressManager: pm,
+			Timeout:         2 * time.Minute,
+		})
+		if err != nil {
+			message.Reply("download error: " + err.Error())
+			return err
+		}
+
+		message.Reply("download finished")
+		return nil
+	}, telegram.FilterPrivate)
+
+	client.Idle()
+}


### PR DESCRIPTION
This PR fixes issue #260 where media downloads randomly hang or get stuck at 0%.  
The root cause was a combination of missing context cancellation, worker initialization race conditions, and infinite retry loops on FILE_REFERENCE_EXPIRED.

###  Fixes
- Download hanging at random percentages
- Infinite retry loop after FILE_REFERENCE_EXPIRED
- Workers not initialized correctly before download starts
- Missing ability to cancel or timeout a download

### Changes
- Add `Timeout` field to `DownloadOptions`
- Propagate context into all download goroutines
- Make `initializeWorkers` synchronous and ensure at least 1 worker exists
- Treat FILE_REFERENCE_EXPIRED as fatal and trigger refetch cleanly
- Add `examples/download` showing timeout + progress usage

### Testing
Tested with:
- photos
- documents
- MP4 videos
- MOV videos
- large files (20–30 MB)

All downloads complete without hanging, and timeout now correctly cancels the routine.

Fixes #260
