### PR TITLE
Implement FakeTLS MTProxy handshake (ee-secret) + Add MTProxy example

### DIFF
--- a/examples/mtproxy/main.go
+++ b/examples/mtproxy/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/amarnathcjd/gogram/telegram"
+)
+
+const (
+	appID     = 6
+	appHash   = "YOUR_APP_HASH"
+	botToken  = "YOUR_BOT_TOKEN"
+	mtproxyURL = "mtproxy://<secret>@<host>:<port>" // replace with your MTProxy URL
+)
+
+func main() {
+	proxyURL, err := url.Parse(mtproxyURL)
+	if err != nil {
+		panic(err)
+	}
+
+	client, _ := telegram.NewClient(telegram.ClientConfig{
+		AppID:    appID,
+		AppHash:  appHash,
+		LogLevel: telegram.LogInfo,
+		Proxy:    proxyURL,
+	})
+
+	if err := client.LoginBot(botToken); err != nil {
+		panic(err)
+	}
+
+	me, err := client.GetMe()
+	if err != nil {
+		panic(err)
+	}
+
+	client.SendMessage("me", fmt.Sprintf("Hello from gogram via MTProxy FakeTLS, %s!", me.FirstName))
+	fmt.Println("Connected via MTProxy as", me.Username)
+}


### PR DESCRIPTION
This PR adds full FakeTLS MTProxy (ee-secret) client-side support to gogram, following behavior consistent with TDLib and gotd:

Implements Client → MTProxy FakeTLS handshake
Adds ChangeCipherSpec record before first application data record
Adds mtproxy://<secret>@host:port support as a proxy URL
Adds examples/mtproxy for end-to-end testing
Improves error logging for MTProxy handshake & DC migration

Example output tested : 
```
moire@nextz:~/Workspace/gogram$ go run ./examples/mtproxy
2025-11-15 14:38:03 [info]  gogram [mtproto] mtproto.go:481 - connecting to [149.154.167.91:443] - <Mtproxy> ...
2025-11-15 14:38:03 [info]  gogram [mtproto] mtproxy.go:707 - [mtproxy] connection established to 91.107.172.155:443 (DC 4)
2025-11-15 14:38:03 [info]  gogram [mtproto] mtproto.go:507 - connection to (~91.107.172.155:443)[149.154.167.91:443] - <Mtproxy> established
2025-11-15 14:38:06 [info]  gogram [mtproto] mtproto.go:365 - user migrated to new dc (5) - 91.108.56.151:443
2025-11-15 14:38:06 [info]  gogram [mtproto] mtproto.go:481 - connecting to [91.108.56.151:443] - <Mtproxy> ...
2025-11-15 14:38:07 [info]  gogram [mtproto] mtproxy.go:707 - [mtproxy] connection established to 91.107.172.155:443 (DC 5)
2025-11-15 14:38:07 [info]  gogram [mtproto] mtproto.go:507 - connection to (~91.107.172.155:443)[91.108.56.151:443] - <Mtproxy> established
Connected via MTProxy as moireankesbot
```