### PR TITLE
feat: add MTProto PFS temp auth key manager

### DIFF
--- a/examples/pfs/main.go
+++ b/examples/pfs/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/amarnathcjd/gogram/telegram"
+)
+
+// Fill these with your real credentials before running.
+const (
+	appID    = 6              // your api_id from my.telegram.org
+	appHash  = "YOUR_APP_HASH" // your api_hash from my.telegram.org
+	botToken = "YOUR_BOT_TOKEN"
+)
+
+func main() {
+	if appID == 0 || appHash == "YOUR_APP_HASH" || botToken == "YOUR_BOT_TOKEN" {
+		panic("please set appID, appHash, and botToken in examples/pfs/main.go before running")
+	}
+
+	client, err := telegram.NewClient(telegram.ClientConfig{
+		AppID:     appID,
+		AppHash:   appHash,
+		Session:   "pfs.session",
+		LogLevel:  telegram.LogDebug,
+		EnablePFS: true,
+	})
+	if err != nil {
+		panic(fmt.Errorf("creating client: %w", err))
+	}
+
+	if err := client.LoginBot(botToken); err != nil {
+		panic(fmt.Errorf("login bot: %w", err))
+	}
+
+	me, err := client.GetMe()
+	if err != nil {
+		panic(fmt.Errorf("get me: %w", err))
+	}
+
+	text := fmt.Sprintf("PFS test: %s (user=%s)", time.Now().Format(time.RFC3339), me.Username)
+	client.SendMessage("me", text)
+
+	fmt.Println("PFS test message sent. Check debug logs for PFS manager, temp auth key creation, and binding.")
+
+	// Keep the client running so that PFS manager can rotate keys over time if desired.
+	client.Idle()
+}

--- a/handshake.go
+++ b/handshake.go
@@ -4,6 +4,7 @@ package gogram
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -17,6 +18,7 @@ import (
 	"github.com/amarnathcjd/gogram/internal/keys"
 	"github.com/amarnathcjd/gogram/internal/math"
 	"github.com/amarnathcjd/gogram/internal/mtproto/objects"
+	"github.com/amarnathcjd/gogram/internal/session"
 	"github.com/amarnathcjd/gogram/internal/utils"
 )
 
@@ -203,4 +205,355 @@ nonceCreate:
 		m.Logger.WithError(err).Error("failed to save session")
 	}
 	return err
+}
+
+// makeTempAuthKey creates a temporary authorization key using p_q_inner_data_temp_dc,
+// as described in the MTProto auth_key documentation. The resulting key is stored
+// in tempAuthKey/tempAuthKeyHash and is not persisted to the session.
+// expiresIn is the desired lifetime of the temporary key in seconds.
+func (m *MTProto) makeTempAuthKey(expiresIn int32) error {
+	if expiresIn <= 0 {
+		expiresIn = 24 * 60 * 60 // default to 24 hours
+	}
+
+	// Use service mode so that responses for the low-level MTProto handshake
+	// (ResPQ, ServerDHParams, etc.) bypass the normal RPC pipeline.
+	m.serviceModeActivated = true
+	defer func() { m.serviceModeActivated = false }()
+
+	maxRetries := 5
+nonceCreate:
+	nonceFirst := tl.RandomInt128()
+	var (
+		res *objects.ResPQ
+		err error
+	)
+
+	if m.cdn {
+		res, err = m.reqPQMulti(nonceFirst)
+	} else {
+		res, err = m.reqPQ(nonceFirst)
+	}
+
+	if err != nil {
+		return fmt.Errorf("reqPQ: %w", err)
+	}
+
+	if nonceFirst.Cmp(res.Nonce.Int) != 0 {
+		if maxRetries > 0 {
+			maxRetries--
+			time.Sleep(200 * time.Millisecond)
+			goto nonceCreate
+		}
+		return fmt.Errorf("reqPQ: nonce mismatch (%v, %v)", nonceFirst, res.Nonce)
+	}
+
+	found := false
+	for _, b := range res.Fingerprints {
+		if m.cdn {
+			for _, key := range m.cdnKeys {
+				if uint64(b) == binary.LittleEndian.Uint64(keys.RSAFingerprint(key)) {
+					found = true
+					m.publicKey = key
+					break
+				}
+			}
+		}
+		if uint64(b) == binary.LittleEndian.Uint64(keys.RSAFingerprint(m.publicKey)) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("reqPQ: no matching fingerprint")
+	}
+
+	// (encoding) p_q_inner_data_temp_dc
+	pq := big.NewInt(0).SetBytes(res.Pq)
+	p, q := math.Factorize(pq)
+	if p == nil || q == nil {
+		p, q = math.Fac(pq)
+	}
+	nonceSecond := tl.RandomInt256()
+	nonceServer := res.ServerNonce
+
+	dcID := int32(m.GetDC())
+	message, err := tl.Marshal(&objects.PQInnerDataTempDc{
+		Pq:          res.Pq,
+		P:           p.Bytes(),
+		Q:           q.Bytes(),
+		Nonce:       nonceFirst,
+		ServerNonce: nonceServer,
+		NewNonce:    nonceSecond,
+		Dc:          dcID,
+		ExpiresIn:   expiresIn,
+	})
+	if err != nil {
+		m.Logger.WithField("error", err).Debug("makeTempAuthKey: failed to marshal pq inner data temp dc")
+		return err
+	}
+
+	hashAndMsg := make([]byte, 255)
+	copy(hashAndMsg, append(utils.Sha1(string(message)), message...))
+
+	encryptedMessage := math.DoRSAencrypt(hashAndMsg, m.publicKey)
+
+	keyFingerprint := int64(binary.LittleEndian.Uint64(keys.RSAFingerprint(m.publicKey)))
+	dhResponse, err := m.reqDHParams(nonceFirst, nonceServer, p.Bytes(), q.Bytes(), keyFingerprint, encryptedMessage)
+	if err != nil {
+		return fmt.Errorf("reqDHParams: %w", err)
+	}
+	dhParams, ok := dhResponse.(*objects.ServerDHParamsOk)
+	if !ok {
+		return fmt.Errorf("reqDHParams: invalid response")
+	}
+
+	if nonceFirst.Cmp(dhParams.Nonce.Int) != 0 {
+		return fmt.Errorf("reqDHParams: nonce mismatch")
+	}
+	if nonceServer.Cmp(dhParams.ServerNonce.Int) != 0 {
+		return fmt.Errorf("reqDHParams: server nonce mismatch")
+	}
+
+	decodedMessage, err := ige.DecryptMessageWithTempKeys(dhParams.EncryptedAnswer, nonceSecond.Int, nonceServer.Int)
+	if err != nil {
+		m.Logger.WithError(err).Debug("decrypt failed - retrying temp auth key generation")
+		return m.makeTempAuthKey(expiresIn)
+	}
+
+	data, err := tl.DecodeUnknownObject(decodedMessage)
+	if err != nil {
+		return fmt.Errorf("decode: %w", err)
+	}
+
+	dhi, ok := data.(*objects.ServerDHInnerData)
+	if !ok {
+		return fmt.Errorf("decode: invalid response")
+	}
+	if nonceFirst.Cmp(dhi.Nonce.Int) != 0 {
+		return fmt.Errorf("decode: nonce mismatch")
+	}
+	if nonceServer.Cmp(dhi.ServerNonce.Int) != 0 {
+		return fmt.Errorf("decode: server nonce mismatch")
+	}
+
+	_, gB, gAB := math.MakeGAB(dhi.G, big.NewInt(0).SetBytes(dhi.GA), big.NewInt(0).SetBytes(dhi.DhPrime))
+
+	tempKey := gAB.Bytes()
+	if tempKey[0] == 0 {
+		tempKey = tempKey[1:]
+	}
+
+	// derive server salt for the temporary key
+	t4 := make([]byte, 32+1+8)
+	copy(t4[0:], nonceSecond.Bytes())
+	t4[32] = 1
+	copy(t4[33:], utils.Sha1Byte(tempKey)[0:8])
+	nonceHash1 := utils.Sha1Byte(t4)[4:20]
+	salt := make([]byte, tl.LongLen)
+	copy(salt, nonceSecond.Bytes()[:8])
+	math.Xor(salt, nonceServer.Bytes()[:8])
+	newSalt := int64(binary.LittleEndian.Uint64(salt))
+
+	clientDHData, err := tl.Marshal(&objects.ClientDHInnerData{
+		Nonce:       nonceFirst,
+		ServerNonce: nonceServer,
+		Retry:       0,
+		GB:          gB.Bytes(),
+	})
+	if err != nil {
+		m.Logger.WithField("error", err).Debug("makeTempAuthKey: failed to marshal client dh inner data")
+		return err
+	}
+
+	encryptedMessage, err = ige.EncryptMessageWithTempKeys(clientDHData, nonceSecond.Int, nonceServer.Int)
+	if err != nil {
+		return errors.New("dh: " + err.Error())
+	}
+
+	dhGenStatus, err := m.setClientDHParams(nonceFirst, nonceServer, encryptedMessage)
+	if err != nil {
+		return errors.New("dh: " + err.Error())
+	}
+
+	dhg, ok := dhGenStatus.(*objects.DHGenOk)
+	if !ok {
+		return fmt.Errorf("invalid response")
+	}
+	if nonceFirst.Cmp(dhg.Nonce.Int) != 0 {
+		return fmt.Errorf("handshake: Wrong nonce: %v, %v", nonceFirst, dhg.Nonce)
+	}
+	if nonceServer.Cmp(dhg.ServerNonce.Int) != 0 {
+		return fmt.Errorf("handshake: Wrong server_nonce: %v, %v", nonceServer, dhg.ServerNonce)
+	}
+	if !bytes.Equal(nonceHash1, dhg.NewNonceHash1.Bytes()) {
+		return fmt.Errorf(
+			"handshake: Wrong new_nonce_hash1: %v, %v",
+			hex.EncodeToString(nonceHash1),
+			hex.EncodeToString(dhg.NewNonceHash1.Bytes()),
+		)
+	}
+
+	// Store temporary auth key and its metadata in memory only.
+	m.tempAuthKey = tempKey
+	m.tempAuthKeyHash = utils.AuthKeyHash(tempKey)
+	m.tempAuthExpiresAt = time.Now().Unix() + int64(expiresIn)
+	m.serverSalt = newSalt
+	return nil
+}
+
+// createTempAuthKey performs the temporary auth key handshake on a separate
+// ephemeral MTProto connection. This avoids interfering with the main
+// connection's RPC pipeline and ensures that the low-level MTProto handshake
+// is always performed in unencrypted mode as required by the protocol.
+func (m *MTProto) createTempAuthKey(expiresIn int32) error {
+	cfg := Config{
+		AuthKeyFile:    "",
+		AuthAESKey:     "",
+		SessionStorage: session.NewInMemory(),
+		MemorySession:  true,
+		AppID:          m.appID,
+		EnablePFS:      false,
+		ServerHost:     m.Addr,
+		PublicKey:      m.publicKey,
+		DataCenter:     m.GetDC(),
+		Logger:         m.Logger.Clone().WithPrefix("gogram [mtproto-pfs]"),
+		Proxy:          m.proxy,
+		Mode:           "", // default transport mode (abridged)
+		Ipv6:           m.IpV6,
+		CustomHost:     true,
+		LocalAddr:      m.localAddr,
+		Timeout:        int(m.timeout.Seconds()),
+		ReqTimeout:     int(m.reqTimeout.Seconds()),
+		UseWebSocket:   m.useWebSocket,
+		UseWebSocketTLS: m.useWebSocketTLS,
+	}
+
+	tmp, err := NewMTProto(cfg)
+	if err != nil {
+		return fmt.Errorf("createTempAuthKey: creating temp MTProto: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := tmp.connect(ctx); err != nil {
+		return fmt.Errorf("createTempAuthKey: connecting temp MTProto: %w", err)
+	}
+	tmp.tcpState.SetActive(true)
+	tmp.startReadingResponses(ctx)
+
+	if err := tmp.makeTempAuthKey(expiresIn); err != nil {
+		return fmt.Errorf("createTempAuthKey: makeTempAuthKey on temp connection: %w", err)
+	}
+
+	// Copy the generated temporary auth key and its metadata back to the main
+	// MTProto instance. The server salt associated with the temporary key is
+	// also propagated so that subsequent messages encrypted with the temp key
+	// use the correct salt.
+	m.tempAuthKey = tmp.tempAuthKey
+	m.tempAuthKeyHash = tmp.tempAuthKeyHash
+	m.tempAuthExpiresAt = tmp.tempAuthExpiresAt
+	m.serverSalt = tmp.serverSalt
+
+	if tmp.transport != nil {
+		_ = tmp.transport.Close()
+	}
+	tmp.tcpState.SetActive(false)
+
+	return nil
+}
+
+// bindTempAuthKey binds the temporary auth key to the permanent auth key using
+// auth.bindTempAuthKey. The outer request is encrypted with the temporary auth
+// key, while the inner binding message is encrypted with the permanent key
+// using MTProto 1.0 as required by the specification.
+func (m *MTProto) bindTempAuthKey() error {
+	if m.tempAuthKey == nil {
+		return errors.New("bindTempAuthKey: tempAuthKey is nil")
+	}
+	if len(m.authKey) == 0 {
+		return errors.New("bindTempAuthKey: permanent authKey is nil")
+	}
+
+	permKeyHash := utils.AuthKeyHash(m.authKey)
+	permAuthKeyID := int64(binary.LittleEndian.Uint64(permKeyHash))
+
+	tempKeyHash := utils.AuthKeyHash(m.tempAuthKey)
+	tempAuthKeyID := int64(binary.LittleEndian.Uint64(tempKeyHash))
+
+	// Use current session ID as temp_session_id for the binding.
+	tempSessionID := m.sessionId
+
+	expiresAt := int32(m.tempAuthExpiresAt)
+	if expiresAt == 0 {
+		expiresAt = int32(time.Now().Unix() + 24*60*60)
+	}
+
+	nonce := utils.GenerateSessionID()
+	msgID := m.genMsgID(m.timeOffset)
+
+	inner := &objects.BindAuthKeyInner{
+		Nonce:         nonce,
+		TempAuthKeyID: tempAuthKeyID,
+		PermAuthKeyID: permAuthKeyID,
+		TempSessionID: tempSessionID,
+		ExpiresAt:     expiresAt,
+	}
+
+	innerBytes, err := tl.Marshal(inner)
+	if err != nil {
+		return fmt.Errorf("marshal BindAuthKeyInner: %w", err)
+	}
+
+	// Build MTProto v1 plaintext: random:int128 + msg_id + seqno(0) + msg_len + inner.
+	random128 := utils.RandomBytes(16)
+	plaintext := make([]byte, 0, 16+8+4+4+len(innerBytes))
+	plaintext = append(plaintext, random128...)
+
+	buf8 := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf8, uint64(msgID))
+	plaintext = append(plaintext, buf8...)
+
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, 0) // seqno = 0
+	plaintext = append(plaintext, buf4...)
+
+	binary.LittleEndian.PutUint32(buf4, uint32(len(innerBytes)))
+	plaintext = append(plaintext, buf4...)
+	plaintext = append(plaintext, innerBytes...)
+
+	// Encrypt binding message with permanent auth key using MTProto 1.0 helpers.
+	cipher, msgKey, err := ige.EncryptV1(plaintext, m.authKey)
+	if err != nil {
+		return fmt.Errorf("encrypt BindAuthKeyInner: %w", err)
+	}
+
+	encryptedMessage := make([]byte, 0, len(permKeyHash)+len(msgKey)+len(cipher))
+	encryptedMessage = append(encryptedMessage, permKeyHash...)
+	encryptedMessage = append(encryptedMessage, msgKey...)
+	encryptedMessage = append(encryptedMessage, cipher...)
+
+	params := &objects.AuthBindTempAuthKeyParams{
+		PermAuthKeyID:    permAuthKeyID,
+		Nonce:            nonce,
+		ExpiresAt:        expiresAt,
+		EncryptedMessage: encryptedMessage,
+	}
+
+	// Send auth.bindTempAuthKey with the same msg_id used inside the MTProto
+	// v1 binding message, as required by the PFS specification.
+	respCh, _, err := m.sendPacketWithMsgID(params, msgID)
+	if err != nil {
+		return fmt.Errorf("auth.bindTempAuthKey: %w", err)
+	}
+
+	response := <-respCh
+	if rpcErr, ok := response.(*objects.RpcError); ok {
+		return fmt.Errorf("auth.bindTempAuthKey: %w", RpcErrorToNative(rpcErr))
+	}
+
+	// Any non-error response is treated as success; the exact Bool value is not
+	// critical here, as the server typically returns true on success.
+	return nil
 }

--- a/internal/mtproto/objects/init.go
+++ b/internal/mtproto/objects/init.go
@@ -14,6 +14,7 @@ func init() {
 		&PingParams{},
 		&ResPQ{},
 		&PQInnerData{},
+		&PQInnerDataTempDc{},
 		&ServerDHParamsFail{},
 		&ServerDHParamsOk{},
 		&ServerDHInnerData{},

--- a/internal/mtproto/objects/methods.go
+++ b/internal/mtproto/objects/methods.go
@@ -37,6 +37,25 @@ func ReqPQ(m requester, nonce *tl.Int128) (*ResPQ, error) {
 	return resp, nil
 }
 
+// AuthBindTempAuthKeyParams is the TL params type for auth.bindTempAuthKey.
+//
+// auth.bindTempAuthKey#cdd42a05 perm_auth_key_id:long nonce:long
+//   expires_at:int encrypted_message:bytes = Bool;
+//
+// Note: this type is intentionally not registered in the global TL registry
+// because the same constructor is already registered in the telegram package.
+// We only use it for encoding requests from the MTProto layer.
+type AuthBindTempAuthKeyParams struct {
+	PermAuthKeyID    int64
+	Nonce            int64
+	ExpiresAt        int32
+	EncryptedMessage []byte
+}
+
+func (*AuthBindTempAuthKeyParams) CRC() uint32 {
+	return 0xcdd42a05
+}
+
 type ReqPQMultiParams struct {
 	Nonce *tl.Int128
 }

--- a/internal/mtproto/objects/types.go
+++ b/internal/mtproto/objects/types.go
@@ -45,6 +45,43 @@ func (*PQInnerData) CRC() uint32 {
 	return 0x83c95aec
 }
 
+// PQInnerDataTempDc represents p_q_inner_data_temp_dc used for generating
+// temporary authorization keys (PFS) as described in MTProto auth_key docs.
+//
+// p_q_inner_data_temp_dc#56fddf88 pq:string p:string q:string nonce:int128
+//   server_nonce:int128 new_nonce:int256 dc:int expires_in:int = P_Q_inner_data;
+func (*PQInnerDataTempDc) CRC() uint32 {
+	return 0x56fddf88
+}
+
+type PQInnerDataTempDc struct {
+	Pq          []byte
+	P           []byte
+	Q           []byte
+	Nonce       *tl.Int128
+	ServerNonce *tl.Int128
+	NewNonce    *tl.Int256
+	Dc          int32
+	ExpiresIn   int32
+}
+
+// BindAuthKeyInner represents the bind_auth_key_inner message used to bind
+// a temporary auth key to a permanent one in auth.bindTempAuthKey.
+//
+// bind_auth_key_inner#75a3f765 nonce:long temp_auth_key_id:long
+//   perm_auth_key_id:long temp_session_id:long expires_at:int = BindAuthKeyInner;
+type BindAuthKeyInner struct {
+	Nonce         int64
+	TempAuthKeyID int64
+	PermAuthKeyID int64
+	TempSessionID int64
+	ExpiresAt     int32
+}
+
+func (*BindAuthKeyInner) CRC() uint32 {
+	return 0x75a3f765
+}
+
 type ServerDHParams interface {
 	tl.Object
 	ImplementsServerDHParams()

--- a/network.go
+++ b/network.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"time"
 
 	"errors"
 
@@ -30,6 +31,70 @@ func (m *MTProto) sendPacket(request tl.Object, expectedTypes ...reflect.Type) (
 	)
 
 	// adding types for parser if required
+	if len(expectedTypes) > 0 {
+		m.expectedTypes.Add(int(msgID), expectedTypes)
+	}
+
+	resp := m.getRespChannel()
+	if isNullableResponse(request) {
+		go func() {
+			resp <- &objects.Null{}
+		}()
+	} else {
+		m.responseChannels.Add(int(msgID), resp)
+	}
+
+	if m.encrypted {
+		data = &messages.Encrypted{
+			Msg:         msg,
+			MsgID:       msgID,
+			AuthKeyHash: m.authKeyHash,
+		}
+	} else {
+		data = &messages.Unencrypted{
+			Msg:   msg,
+			MsgID: msgID,
+		}
+	}
+
+	var seqNo int32
+	if isNotContentRelated(request) {
+		seqNo = m.GetSeqNo()
+	} else {
+		seqNo = m.UpdateSeqNo()
+	}
+
+	if m.transport == nil || !m.IsTcpActive() {
+		err := m.CreateConnection(false)
+		if err != nil || m.transport == nil {
+			return nil, 0, errors.New("failed to establish connection, transport is nil")
+		}
+	}
+
+	maxRetries := 2
+sendPacket:
+	errorSendPacket := m.transport.WriteMsg(data, seqNo)
+	if errorSendPacket != nil {
+		if maxRetries > 0 && (strings.Contains(errorSendPacket.Error(), "connection was aborted") || strings.Contains(errorSendPacket.Error(), "connection reset")) {
+			maxRetries--
+			err := m.CreateConnection(false)
+			if err == nil && m.transport != nil {
+				goto sendPacket
+			}
+		}
+		return nil, msgID, fmt.Errorf("writing message: %w", errorSendPacket)
+	}
+	return resp, msgID, nil
+}
+
+func (m *MTProto) sendPacketWithMsgID(request tl.Object, msgID int64, expectedTypes ...reflect.Type) (chan tl.Object, int64, error) {
+	msg, err := tl.Marshal(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("marshaling request: %w", err)
+	}
+
+	var data messages.Common
+
 	if len(expectedTypes) > 0 {
 		m.expectedTypes.Add(int(msgID), expectedTypes)
 	}
@@ -162,9 +227,21 @@ func (m *MTProto) GetServerSalt() int64 {
 	return m.serverSalt
 }
 
-// GetAuthKey returns decryption key of current session salt 🧐
-func (m *MTProto) GetAuthKey() []byte {
+// activeAuthKey returns the currently active auth key.
+// If PFS is enabled and a valid temporary auth key is present, it is preferred.
+// Otherwise, the permanent auth key is returned.
+func (m *MTProto) activeAuthKey() []byte {
+	if m.enablePFS && m.tempAuthKey != nil {
+		if m.tempAuthExpiresAt == 0 || time.Now().Unix() < m.tempAuthExpiresAt {
+			return m.tempAuthKey
+		}
+	}
 	return m.authKey
+}
+
+// GetAuthKey returns the current auth key used for message encryption.
+func (m *MTProto) GetAuthKey() []byte {
+	return m.activeAuthKey()
 }
 
 func (m *MTProto) SetAuthKey(key []byte) {

--- a/telegram/client.go
+++ b/telegram/client.go
@@ -107,6 +107,7 @@ type ClientConfig struct {
 	ReqTimeout       int                  // Rpc request timeout in seconds (default: 60s)
 	UseWebSocket     bool                 // Use WebSocket transport instead of TCP
 	UseWebSocketTLS  bool                 // Use wss:// (WebSocket over TLS) instead of ws://
+	EnablePFS        bool                 // Enable Perfect Forward Secrecy using temporary auth keys
 }
 
 type Session struct {
@@ -203,6 +204,7 @@ func (c *Client) setupMTProto(config ClientConfig) error {
 		ReqTimeout:      config.ReqTimeout,
 		UseWebSocket:    config.UseWebSocket,
 		UseWebSocketTLS: config.UseWebSocketTLS,
+		EnablePFS:       config.EnablePFS,
 	}
 
 	if config.Proxy != nil {


### PR DESCRIPTION
This PR introduces full support for MTProto PFS (Perfect Forward Secrecy) by implementing a temporary auth key manager and binding workflow.


Added temporary auth key generation using p_q_inner_data_temp_dc
Added auth.bindTempAuthKey binding flow (MTProto 1.0 encrypted inner message)
Implemented ephemeral MTProto connection for isolated temp key handshake
Added AES-IGE MTProto v1 helpers for binding encryption
Added debug logging for PFS operations
Included example program (examples/pfs) demonstrating PFS key creation, binding, and usage
Updated TL objects: PQInnerDataTempDc, BindAuthKeyInner, and related CRCs
Updated MTProto core to store temp key, key hash, expiration, and salt