### PR TITLE
fix finish takeout session

### DIFF
--- a/telegram/methods_gen.go
+++ b/telegram/methods_gen.go
@@ -465,8 +465,11 @@ func (*AccountFinishTakeoutSessionParams) FlagIndex() int {
 }
 
 // Terminate a takeout session
-func (c *Client) AccountFinishTakeoutSession(success bool) (bool, error) {
-	responseData, err := c.MakeRequest(&AccountFinishTakeoutSessionParams{Success: success})
+func (c *Client) AccountFinishTakeoutSession(takeoutID int64, success bool) (bool, error) {
+	responseData, err := c.MakeRequest(&InvokeWithTakeoutParams{
+		TakeoutID: takeoutID,
+		Query:     &AccountFinishTakeoutSessionParams{Success: success},
+})
 	if err != nil {
 		return false, fmt.Errorf("sending AccountFinishTakeoutSession: %w", err)
 	}


### PR DESCRIPTION
account.finishTakeoutSession required to call with invokeWithTakeout. Instead telegram returns 403 TAKEOUT_REQUIRED

[example from tdesktop](https://github.com/telegramdesktop/tdesktop/blob/5d73ce822d601a2d1557415bbceaf9e7a00a1575/Telegram/SourceFiles/export/export_api_wrap.cpp#L1541-L1543)